### PR TITLE
Add Nero API consumption servlet and JSPs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,10 +103,20 @@
                         <artifactId>jbcrypt</artifactId>
                         <version>0.4</version>
                 </dependency>
-		<!--   JUnit   -->
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
+                <dependency>
+                        <groupId>org.glassfish.jersey.core</groupId>
+                        <artifactId>jersey-client</artifactId>
+                        <version>3.1.8</version>
+                </dependency>
+                <dependency>
+                        <groupId>org.glassfish.jersey.media</groupId>
+                        <artifactId>jersey-media-json-jackson</artifactId>
+                        <version>3.1.8</version>
+                </dependency>
+                <!--   JUnit   -->
+                <dependency>
+                        <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
 			<version>4.13.2</version>
 			<scope>test</scope>
 		</dependency>

--- a/src/main/java/com/pinguela/rentexpressweb/controller/ConsumesApi.java
+++ b/src/main/java/com/pinguela/rentexpressweb/controller/ConsumesApi.java
@@ -1,0 +1,223 @@
+package com.pinguela.rentexpressweb.controller;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@WebServlet("/consumesapi")
+public class ConsumesApi extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+    private static final String BASE_URI = "http://localhost:8080/neroveterinaria-rest/api";
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        Client client = ClientBuilder.newClient();
+
+        WebTarget webTarget = client
+                .target(BASE_URI)
+                .path("open")
+                .path("appointment")
+                .path("date")
+                .path("2025-01-01")
+                .queryParam("language", "es");
+
+        Invocation.Builder invocationBuilder = webTarget.request(MediaType.APPLICATION_JSON);
+
+        String jsonResponse = invocationBuilder.get(String.class);
+        System.out.println("Raw Response: " + jsonResponse);
+
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            JsonNode rootNode = mapper.readTree(jsonResponse);
+            if (rootNode != null && rootNode.isArray()) {
+                for (JsonNode appointmentNode : rootNode) {
+                    JsonNode idNode = appointmentNode.get("id");
+                    if (idNode != null) {
+                        int id = idNode.asInt();
+                        System.out.println("Appointment id: " + id);
+                    }
+                }
+            } else {
+                System.out.println("Response is not a JSON array.");
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        response.getWriter().append("OK ConsumesApi GET");
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        String action = request.getParameter("action");
+
+        if (action == null) {
+            handleLogin(request, response);
+        } else if ("create_appointment".equals(action)) {
+            handleCreateAppointment(request, response);
+        } else {
+            response.getWriter().append("Acción no soportada");
+        }
+    }
+
+    private void handleLogin(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        String email = request.getParameter("email");
+        String password = request.getParameter("password");
+
+        if (email == null || email.isEmpty() || password == null || password.isEmpty()) {
+            response.getWriter().append("Faltan credenciales");
+            return;
+        }
+
+        Client client = ClientBuilder.newClient();
+        String encodedEmail = URLEncoder.encode(email, StandardCharsets.UTF_8.toString());
+
+        WebTarget webTarget = client
+                .target(BASE_URI)
+                .path("client")
+                .path("athenticate")
+                .path(encodedEmail)
+                .queryParam("password", password)
+                .queryParam("language", "es");
+
+        Invocation.Builder invocationBuilder = webTarget.request(MediaType.APPLICATION_JSON);
+
+        Response apiResponse = invocationBuilder.get();
+        int status = apiResponse.getStatus();
+        String jsonResponse = apiResponse.readEntity(String.class);
+
+        System.out.println("Authenticate status: " + status);
+        System.out.println("Raw Response authenticate: " + jsonResponse);
+
+        if (status == Response.Status.OK.getStatusCode()) {
+            ObjectMapper mapper = new ObjectMapper();
+            try {
+                JsonNode rootNode = mapper.readTree(jsonResponse);
+                if (rootNode != null) {
+                    int id = rootNode.path("id").asInt();
+                    String name = rootNode.path("name").asText("");
+                    String emailResponse = rootNode.path("email").asText(email);
+
+                    HttpSession session = request.getSession(true);
+                    session.setAttribute("neroClientId", id);
+                    session.setAttribute("neroClientName", name);
+                    session.setAttribute("neroClientEmail", emailResponse);
+
+                    response.getWriter().append("Login Nero OK. Cliente: " + name + " (id=" + id + ")");
+                    return;
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+
+        response.getWriter().append("Credenciales incorrectas");
+    }
+
+    private void handleCreateAppointment(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        HttpSession session = request.getSession(false);
+        Integer neroClientId = session != null ? (Integer) session.getAttribute("neroClientId") : null;
+
+        String headquartersIdParam = request.getParameter("headquartersId");
+        String dateParam = request.getParameter("date");
+        String timeParam = request.getParameter("time");
+        String details = request.getParameter("details");
+
+        String errorMessage = null;
+
+        if (neroClientId == null) {
+            errorMessage = "No existe un cliente Nero autenticado en sesión.";
+        } else if (headquartersIdParam == null || headquartersIdParam.isEmpty() || dateParam == null
+                || dateParam.isEmpty() || timeParam == null || timeParam.isEmpty()) {
+            errorMessage = "Datos de cita incompletos.";
+        }
+
+        if (errorMessage != null) {
+            request.setAttribute("neroAppointmentError", errorMessage);
+            forwardToAppointmentJsp(request, response);
+            return;
+        }
+
+        LocalDate date = LocalDate.parse(dateParam);
+        LocalTime time = LocalTime.parse(timeParam);
+        LocalDateTime dateTime = LocalDateTime.of(date, time);
+        String dateTimeIso = dateTime.toString();
+
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode appointmentJson = mapper.createObjectNode();
+        appointmentJson.put("clientId", neroClientId);
+        appointmentJson.put("headquartersId", Integer.parseInt(headquartersIdParam));
+        appointmentJson.put("dateTime", dateTimeIso);
+        appointmentJson.put("details", details);
+
+        Client client = ClientBuilder.newClient();
+
+        WebTarget webTarget = client
+                .target(BASE_URI)
+                .path("open")
+                .path("appointment")
+                .queryParam("language", "es");
+
+        Invocation.Builder invocationBuilder = webTarget.request(MediaType.APPLICATION_JSON);
+
+        Response apiResponse = invocationBuilder.post(
+                Entity.entity(appointmentJson.toString(), MediaType.APPLICATION_JSON));
+
+        int status = apiResponse.getStatus();
+        String jsonResponse = apiResponse.readEntity(String.class);
+
+        System.out.println("Create appointment status: " + status);
+        System.out.println("Create appointment body: " + jsonResponse);
+
+        if (status == Response.Status.OK.getStatusCode()) {
+            Integer appointmentId = null;
+            try {
+                JsonNode responseNode = mapper.readTree(jsonResponse);
+                if (responseNode != null) {
+                    if (responseNode.isInt()) {
+                        appointmentId = responseNode.asInt();
+                    } else if (responseNode.has("id")) {
+                        appointmentId = responseNode.get("id").asInt();
+                    }
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+
+            request.setAttribute("neroAppointmentId", appointmentId);
+            request.setAttribute("neroAppointmentSuccess", true);
+        } else {
+            request.setAttribute("neroAppointmentError", "Error al crear la cita en Nero. Código: " + status);
+        }
+
+        forwardToAppointmentJsp(request, response);
+    }
+
+    private void forwardToAppointmentJsp(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        RequestDispatcher dispatcher = request.getRequestDispatcher("/public/nero_appointment.jsp");
+        dispatcher.forward(request, response);
+    }
+}

--- a/src/main/webapp/public/nero_appointment.jsp
+++ b/src/main/webapp/public/nero_appointment.jsp
@@ -1,0 +1,60 @@
+<%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt"%>
+
+<fmt:setLocale value="${sessionScope.appLocale}" />
+<fmt:setBundle basename="i18n.Messages" />
+
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title><fmt:message key="nero.appointment.title" /></title>
+  <link rel="stylesheet" href="${pageContext.request.contextPath}/css/main.css" />
+</head>
+<body>
+  <%@ include file="/common/header.jsp" %>
+
+  <main class="container">
+    <h1><fmt:message key="nero.appointment.heading" /></h1>
+
+    <p>
+      <fmt:message key="nero.appointment.welcome" />
+      <strong>${sessionScope.neroClientName}</strong>
+    </p>
+
+    <c:if test="${neroAppointmentSuccess}">
+      <div class="alert alert-success">
+        <fmt:message key="nero.appointment.success" />:
+        <strong>${neroAppointmentId}</strong>
+      </div>
+    </c:if>
+
+    <c:if test="${not empty neroAppointmentError}">
+      <div class="alert alert-danger">
+        ${neroAppointmentError}
+      </div>
+    </c:if>
+
+    <form method="post" action="${pageContext.request.contextPath}/consumesapi">
+      <input type="hidden" name="action" value="create_appointment" />
+
+      <label for="headquartersId"><fmt:message key="nero.appointment.headquarters" /></label>
+      <input type="text" id="headquartersId" name="headquartersId" required />
+
+      <label for="date"><fmt:message key="nero.appointment.date" /></label>
+      <input type="date" id="date" name="date" required />
+
+      <label for="time"><fmt:message key="nero.appointment.time" /></label>
+      <input type="time" id="time" name="time" required />
+
+      <label for="details"><fmt:message key="nero.appointment.details" /></label>
+      <textarea id="details" name="details" rows="3"></textarea>
+
+      <button type="submit"><fmt:message key="nero.appointment.submit" /></button>
+    </form>
+  </main>
+
+  <%@ include file="/common/footer.jsp" %>
+</body>
+</html>

--- a/src/main/webapp/public/nero_login.jsp
+++ b/src/main/webapp/public/nero_login.jsp
@@ -1,0 +1,35 @@
+<%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt"%>
+
+<fmt:setLocale value="${sessionScope.appLocale}" />
+<fmt:setBundle basename="i18n.Messages" />
+
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title><fmt:message key="nero.login.title" /></title>
+  <link rel="stylesheet" href="${pageContext.request.contextPath}/css/main.css" />
+</head>
+<body>
+  <%@ include file="/common/header.jsp" %>
+
+  <main class="container">
+    <h1><fmt:message key="nero.login.heading" /></h1>
+    <p><fmt:message key="nero.login.description" /></p>
+
+    <form method="post" action="${pageContext.request.contextPath}/consumesapi">
+      <label for="email"><fmt:message key="nero.login.email" /></label>
+      <input type="email" id="email" name="email" required />
+
+      <label for="password"><fmt:message key="nero.login.password" /></label>
+      <input type="password" id="password" name="password" required />
+
+      <button type="submit"><fmt:message key="nero.login.submit" /></button>
+    </form>
+  </main>
+
+  <%@ include file="/common/footer.jsp" %>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Jersey client dependencies for interacting with NeroVeterinaria endpoints
- implement ConsumesApi servlet to consume appointment queries, authenticate clients, and create appointments via Jersey
- add Nero login and appointment JSP pages to trigger servlet interactions

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69314d989df48323938aa3522a13f1e9)