### PR TITLE
Improve Nero login flow and add FAQ link

### DIFF
--- a/src/main/java/com/pinguela/rentexpressweb/controller/ConsumesApi.java
+++ b/src/main/java/com/pinguela/rentexpressweb/controller/ConsumesApi.java
@@ -82,7 +82,7 @@ public class ConsumesApi extends HttpServlet {
         }
     }
 
-    private void handleLogin(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    private void handleLogin(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
         String email = request.getParameter("email");
         String password = request.getParameter("password");
 
@@ -125,7 +125,8 @@ public class ConsumesApi extends HttpServlet {
                     session.setAttribute("neroClientName", name);
                     session.setAttribute("neroClientEmail", emailResponse);
 
-                    response.getWriter().append("Login Nero OK. Cliente: " + name + " (id=" + id + ")");
+                    request.setAttribute("neroAppointmentInfo", "Login Nero OK. Ahora puedes crear una cita.");
+                    forwardToAppointmentJsp(request, response);
                     return;
                 }
             } catch (IOException e) {

--- a/src/main/webapp/public/index.jsp
+++ b/src/main/webapp/public/index.jsp
@@ -220,6 +220,12 @@
             <div class="col-lg-5">
                 <h2 class="fw-bold mb-3"><fmt:message key="home.faq.title" /></h2>
                 <p class="text-muted mb-4"><fmt:message key="home.faq.subtitle" /></p>
+                <p class="nero-faq mb-4">
+                    ¿Tuviste un percance con tu mascota u otra mientras conduces?
+                    <a href="${pageContext.request.contextPath}/public/nero_login.jsp">
+                        Reserva una cita con NeroVeterinaria
+                    </a>.
+                </p>
                 <div class="d-flex align-items-center gap-3">
                     <div class="feature-icon m-0"><i class="bi bi-chat-dots"></i></div>
                     <div>


### PR DESCRIPTION
## Summary
- forward successful Nero login directly to the appointment page after storing session data
- add FAQ-style link on the public index page to guide users to the Nero login form

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69314fd5dfcc8323aad08975fbe5a57a)