### PR TITLE
Use javax servlet APIs for JSP compilation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,28 +30,23 @@
                         <artifactId>RentExpres-middleware</artifactId>
                         <version>1.0.0</version>
                 </dependency>
-                <!-- Jakarta EE APIs (para Tomcat 10 / Jakarta EE 10) -->
+                <!-- Java EE APIs (para Tomcat 9 / Servlet 4.0) -->
                 <dependency>
-                        <groupId>jakarta.servlet</groupId>
-                        <artifactId>jakarta.servlet-api</artifactId>
-                        <version>5.0.0</version>
+                        <groupId>javax.servlet</groupId>
+                        <artifactId>javax.servlet-api</artifactId>
+                        <version>4.0.1</version>
                         <scope>provided</scope>
                 </dependency>
                 <dependency>
-                        <groupId>jakarta.servlet.jsp</groupId>
-                        <artifactId>jakarta.servlet.jsp-api</artifactId>
-                        <version>3.0.0</version>
+                        <groupId>javax.servlet.jsp</groupId>
+                        <artifactId>javax.servlet.jsp-api</artifactId>
+                        <version>2.3.3</version>
                         <scope>provided</scope>
                 </dependency>
                 <dependency>
-                        <groupId>jakarta.servlet.jsp.jstl</groupId>
-                        <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
-                        <version>2.0.0</version>
-                </dependency>
-                <dependency>
-                        <groupId>org.glassfish.web</groupId>
-                        <artifactId>jakarta.servlet.jsp.jstl</artifactId>
-                        <version>2.0.0</version>
+                        <groupId>javax.servlet</groupId>
+                        <artifactId>jstl</artifactId>
+                        <version>1.2</version>
                 </dependency>
 		<!--   MySQL Connector (driver JDBC)   -->
 		<dependency>


### PR DESCRIPTION
## Summary
- switch servlet and JSP dependencies to the javax (Servlet 4.0) artifacts to match the web.xml configuration

## Testing
- mvn -DskipTests package *(fails: blocked downloading maven-resources-plugin from repo.maven.apache.org, HTTP 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931510b8254832393f60076f45e238c)