### PR TITLE
Align JSP taglib URIs with Jakarta namespace

### DIFF
--- a/src/main/webapp/private/employee_list.jsp
+++ b/src/main/webapp/private/employee_list.jsp
@@ -1,6 +1,6 @@
 <%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 <fmt:setBundle basename="i18n.Messages" />
 <fmt:setLocale value="${sessionScope.appLocale != null ? sessionScope.appLocale : pageContext.request.locale}" />
 <%@ include file="/common/header.jsp" %>

--- a/src/main/webapp/private/profile.jsp
+++ b/src/main/webapp/private/profile.jsp
@@ -1,6 +1,6 @@
 <%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 <%@ include file="/common/header.jsp" %>
 <c:set var="profileType" value="${requestScope.profileType}" />
 <c:set var="userProfile" value="${requestScope.userProfileData}" />

--- a/src/main/webapp/private/vehicle_list.jsp
+++ b/src/main/webapp/private/vehicle_list.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <fmt:setBundle basename="i18n.Messages" />
 <fmt:setLocale value="${sessionScope.appLocale != null ? sessionScope.appLocale : pageContext.request.locale}" />
 <%@ include file="/common/header.jsp" %>

--- a/src/main/webapp/public/nero_appointment.jsp
+++ b/src/main/webapp/public/nero_appointment.jsp
@@ -1,6 +1,6 @@
 <%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt"%>
+<%@ taglib prefix="c" uri="jakarta.tags.core"%>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt"%>
 
 <fmt:setLocale value="${sessionScope.appLocale}" />
 <fmt:setBundle basename="i18n.Messages" />

--- a/src/main/webapp/public/nero_login.jsp
+++ b/src/main/webapp/public/nero_login.jsp
@@ -1,6 +1,6 @@
 <%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt"%>
+<%@ taglib prefix="c" uri="jakarta.tags.core"%>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt"%>
 
 <fmt:setLocale value="${sessionScope.appLocale}" />
 <fmt:setBundle basename="i18n.Messages" />

--- a/src/main/webapp/public/pagination.jsp
+++ b/src/main/webapp/public/pagination.jsp
@@ -1,6 +1,6 @@
 <%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 <c:set var="_paginationCurrentPage"
        value="${empty requestScope.paginationCurrentPage ? 1 : requestScope.paginationCurrentPage}" />
 <c:set var="_paginationTotalPages"

--- a/src/main/webapp/public/vehicleCard.jsp
+++ b/src/main/webapp/public/vehicleCard.jsp
@@ -1,6 +1,6 @@
 <%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 <c:if test="${empty ctx}">
     <c:set var="ctx" value="${pageContext.request.contextPath}" scope="request" />
 </c:if>

--- a/src/main/webapp/public/vehicle_list.jsp
+++ b/src/main/webapp/public/vehicle_list.jsp
@@ -1,7 +1,7 @@
 <%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
-<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
-<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
-<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 <fmt:setLocale value="${sessionScope.appLocale != null ? sessionScope.appLocale : pageContext.request.locale}" scope="session" />
 <fmt:setBundle basename="i18n.Messages" scope="session" />
 <%@ include file="/common/header.jsp" %>


### PR DESCRIPTION
## Summary
- update all JSP taglib declarations to use Jakarta JSTL URIs consistently
- prevent duplicate prefix errors when including shared headers/footers

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931603721508323a1e0d39718c04419)