### PR TITLE
Improve Nero login call-to-action in FAQ

### DIFF
--- a/src/main/webapp/css/main.css
+++ b/src/main/webapp/css/main.css
@@ -2123,6 +2123,38 @@ main {
     margin-bottom: 0;
 }
 
+.nero-cta-card {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 1rem 1.25rem;
+    border-radius: 1.25rem;
+    border: 1px solid rgba(var(--rentexpress-primary-rgb), 0.15);
+    background: linear-gradient(120deg, rgba(var(--rentexpress-primary-rgb), 0.08), #fff 70%);
+    box-shadow: 0 10px 30px rgba(var(--rentexpress-text-rgb), 0.08);
+}
+
+.nero-cta-icon {
+    width: 48px;
+    height: 48px;
+    border-radius: 14px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(var(--rentexpress-primary-rgb), 0.12);
+    color: var(--rentexpress-primary);
+    font-size: 1.25rem;
+}
+
+.nero-cta-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-weight: 600;
+    padding-inline: 1.25rem;
+    box-shadow: 0 10px 30px rgba(var(--rentexpress-primary-rgb), 0.35);
+}
+
 .accordion-button:not(.collapsed) {
     color: var(--rentexpress-primary);
     background-color: rgba(var(--rentexpress-primary-rgb), 0.08);

--- a/src/main/webapp/public/index.jsp
+++ b/src/main/webapp/public/index.jsp
@@ -222,12 +222,21 @@
             <div class="col-lg-5">
                 <h2 class="fw-bold mb-3"><fmt:message key="home.faq.title" /></h2>
                 <p class="text-muted mb-4"><fmt:message key="home.faq.subtitle" /></p>
-                <p class="nero-faq mb-4">
-                    ¿Tuviste un percance con tu mascota u otra mientras conduces?
-                    <a href="${pageContext.request.contextPath}/public/nero_login.jsp">
-                        Reserva una cita con NeroVeterinaria
-                    </a>.
-                </p>
+                <div class="nero-cta-card mb-4">
+                    <div class="nero-cta-icon">
+                        <i class="bi bi-shield-plus"></i>
+                    </div>
+                    <div>
+                        <p class="mb-1 fw-semibold text-uppercase text-primary small">Atención en ruta</p>
+                        <p class="nero-faq mb-3">
+                            ¿Tuviste un percance con tu mascota u otra mientras conduces? Reserva una cita con NeroVeterinaria.
+                        </p>
+                        <a class="btn btn-primary nero-cta-btn" href="${pageContext.request.contextPath}/public/nero_login.jsp">
+                            <span>Ir al login de Nero</span>
+                            <i class="bi bi-arrow-right-short"></i>
+                        </a>
+                    </div>
+                </div>
                 <div class="d-flex align-items-center gap-3">
                     <div class="feature-icon m-0"><i class="bi bi-chat-dots"></i></div>
                     <div>


### PR DESCRIPTION
## Summary
- restyle the NeroVeterinaria FAQ prompt into a highlighted call-to-action card
- add a clear login button with icon to direct users to the Nero access page

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693161bf2e488323b5a25f4faee05eab)