### PR TITLE
Add JSTL configuration blocks to JSP pages

### DIFF
--- a/src/main/webapp/private/dashboard.jsp
+++ b/src/main/webapp/private/dashboard.jsp
@@ -1,5 +1,18 @@
 <%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+
+<%-- ============================================
+     CONFIGURACIÓN
+     ============================================ --%>
+<fmt:setLocale value="${sessionScope.appLocale != null ? sessionScope.appLocale : pageContext.request.locale}" scope="session" />
+<fmt:setBundle basename="i18n.Messages" scope="session" />
+<c:set var="ctx" value="${pageContext.request.contextPath}" />
 <%@ include file="/common/header.jsp" %>
+
+<%-- ============================================
+     FORMULARIO/CONTENIDO
+     ============================================ --%>
 <section class="private-section py-6">
     <div class="container">
         <header class="page-header">

--- a/src/main/webapp/private/employee_form.jsp
+++ b/src/main/webapp/private/employee_form.jsp
@@ -1,6 +1,25 @@
 <%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
-<%@ include file="/common/header.jsp" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+
+<%-- ============================================
+     CONFIGURACIÓN
+     ============================================ --%>
+<fmt:setLocale value="${sessionScope.appLocale != null ? sessionScope.appLocale : pageContext.request.locale}" scope="session" />
+<fmt:setBundle basename="i18n.Messages" scope="session" />
+<c:set var="ctx" value="${pageContext.request.contextPath}" />
 <c:set var="employee" value="${requestScope.employee}" />
+<c:set var="errors" value="${requestScope.errors}" />
+<c:set var="errorGeneral" value="${requestScope.errorGeneral}" />
+<%@ include file="/common/header.jsp" %>
+
+<%-- ============================================
+     VALIDACIONES
+     ============================================ --%>
+
+<%-- ============================================
+     FORMULARIO/CONTENIDO
+     ============================================ --%>
 <section class="private-section py-6">
     <div class="container narrow">
         <header class="page-header">
@@ -17,10 +36,9 @@
             </h2>
             <p class="page-subtitle"><fmt:message key="employee.manage.section.employees.help" /></p>
         </header>
-        <c:if test="${not empty requestScope.errorGeneral}">
-            <div class="alert alert-danger">${requestScope.errorGeneral}</div>
+        <c:if test="${not empty errorGeneral}">
+            <div class="alert alert-danger">${errorGeneral}</div>
         </c:if>
-        <c:set var="errors" value="${requestScope.errors}" />
         <c:if test="${errors != null and not errors.isEmpty()}">
             <div class="alert alert-danger" role="alert">
                 <c:forEach var="entry" items="${errors.all}">

--- a/src/main/webapp/private/vehicle_form.jsp
+++ b/src/main/webapp/private/vehicle_form.jsp
@@ -1,6 +1,25 @@
 <%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
-<%@ include file="/common/header.jsp" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+
+<%-- ============================================
+     CONFIGURACIÓN
+     ============================================ --%>
+<fmt:setLocale value="${sessionScope.appLocale != null ? sessionScope.appLocale : pageContext.request.locale}" scope="session" />
+<fmt:setBundle basename="i18n.Messages" scope="session" />
+<c:set var="ctx" value="${pageContext.request.contextPath}" />
 <c:set var="vehicle" value="${requestScope.vehicle}" />
+<c:set var="errors" value="${requestScope.errors}" />
+<c:set var="errorGeneral" value="${requestScope.errorGeneral}" />
+<%@ include file="/common/header.jsp" %>
+
+<%-- ============================================
+     VALIDACIONES
+     ============================================ --%>
+
+<%-- ============================================
+     FORMULARIO/CONTENIDO
+     ============================================ --%>
 <section class="private-section py-6">
     <div class="container narrow">
         <header class="page-header">
@@ -17,10 +36,9 @@
             </h2>
             <p class="page-subtitle"><fmt:message key="vehicle.manage.filters.title" /></p>
         </header>
-        <c:if test="${not empty requestScope.errorGeneral}">
-            <div class="alert alert-danger">${requestScope.errorGeneral}</div>
+        <c:if test="${not empty errorGeneral}">
+            <div class="alert alert-danger">${errorGeneral}</div>
         </c:if>
-        <c:set var="errors" value="${requestScope.errors}" />
         <c:if test="${errors != null and not errors.isEmpty()}">
             <div class="alert alert-danger" role="alert">
                 <c:forEach var="entry" items="${errors.all}">

--- a/src/main/webapp/public/forgot_password.jsp
+++ b/src/main/webapp/public/forgot_password.jsp
@@ -1,5 +1,24 @@
 <%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+
+<%-- ============================================
+     CONFIGURACIÓN
+     ============================================ --%>
+<fmt:setLocale value="${sessionScope.appLocale != null ? sessionScope.appLocale : pageContext.request.locale}" scope="session" />
+<fmt:setBundle basename="i18n.Messages" scope="session" />
+<c:set var="ctx" value="${pageContext.request.contextPath}" />
+<c:set var="errorEmail" value="${requestScope.errorEmail}" />
+<c:set var="requestEmail" value="${requestScope.email}" />
 <%@ include file="/common/header.jsp" %>
+
+<%-- ============================================
+     VALIDACIONES
+     ============================================ --%>
+
+<%-- ============================================
+     FORMULARIO/CONTENIDO
+     ============================================ --%>
 <section class="auth-section py-6">
     <div class="container">
         <div class="auth-layout card-common shadow-soft">
@@ -10,12 +29,12 @@
             </div>
             <form method="post" action="${ctx}/public/security/recovery" class="auth-form form-grid single-column">
                 <input type="hidden" name="action" value="request" />
-                <c:if test="${not empty requestScope.errorEmail}">
-                    <div class="alert alert-danger">${requestScope.errorEmail}</div>
+                <c:if test="${not empty errorEmail}">
+                    <div class="alert alert-danger">${errorEmail}</div>
                 </c:if>
                 <div class="form-group">
                     <label for="email"><fmt:message key="recovery.request.email" /></label>
-                    <input type="email" id="email" name="email" value="${requestScope.email}" required />
+                    <input type="email" id="email" name="email" value="${requestEmail}" required />
                 </div>
                 <div class="form-actions full-width">
                     <button type="submit" class="btn-brand"><fmt:message key="recovery.request.submit" /></button>

--- a/src/main/webapp/public/register_user.jsp
+++ b/src/main/webapp/public/register_user.jsp
@@ -1,6 +1,16 @@
 <%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
-<%@ include file="/common/header.jsp" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+<%@ taglib prefix="fn" uri="jakarta.tags.functions" %>
 
+<%-- ============================================
+     CONFIGURACIÓN
+     ============================================ --%>
+<fmt:setLocale value="${sessionScope.appLocale != null ? sessionScope.appLocale : pageContext.request.locale}" scope="session" />
+<fmt:setBundle basename="i18n.Messages" scope="session" />
+<c:set var="ctx" value="${pageContext.request.contextPath}" />
+<c:set var="provinces" value="${requestScope.provinces}" />
+<c:set var="cities" value="${requestScope.cities}" />
 <c:url var="citiesByProvinceUrl" value="/public/cities/by-province" />
 <fmt:message var="firstNamePlaceholder" key="register.firstName" />
 <fmt:message var="lastName1Placeholder" key="register.lastName1" />
@@ -16,6 +26,16 @@
 <fmt:message var="provinceLabel" key="register.province" />
 <fmt:message var="cityPlaceholder" key="register.city.placeholder" />
 <fmt:message var="cityLabel" key="register.city" />
+<%@ include file="/common/header.jsp" %>
+
+<%-- ============================================
+     VALIDACIONES
+     ============================================ --%>
+<c:set var="flashError" value="${requestScope.flashError}" />
+
+<%-- ============================================
+     FORMULARIO/CONTENIDO
+     ============================================ --%>
 
 <section class="auth-section register-section py-6">
   <div class="container">
@@ -33,8 +53,8 @@
           </ul>
         </div>
 
-        <c:if test="${not empty requestScope.flashError}">
-          <div class="alert alert-danger" role="alert">${requestScope.flashError}</div>
+        <c:if test="${not empty flashError}">
+          <div class="alert alert-danger" role="alert">${flashError}</div>
         </c:if>
         <form method="post" action="${ctx}/public/users/register" class="auth-form form-grid two-columns">
           <input type="text" name="firstName" class="input-field" placeholder="${firstNamePlaceholder}" required

--- a/src/main/webapp/public/reservation_form.jsp
+++ b/src/main/webapp/public/reservation_form.jsp
@@ -1,5 +1,13 @@
 <%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
-<%@ include file="/common/header.jsp" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+
+<%-- ============================================
+     CONFIGURACIÓN
+     ============================================ --%>
+<fmt:setLocale value="${sessionScope.appLocale != null ? sessionScope.appLocale : pageContext.request.locale}" scope="session" />
+<fmt:setBundle basename="i18n.Messages" scope="session" />
+<c:set var="ctx" value="${pageContext.request.contextPath}" />
 <c:set var="cartVehicle" value="${requestScope.reservationCartVehicle}" />
 <c:set var="headquarters" value="${requestScope.headquarters}" />
 <c:set var="formStartDate" value="${requestScope.reservationParamStartDate}" />
@@ -12,7 +20,18 @@
 <fmt:message var="reservationHeadquartersHint" key="reservation.form.help.headquarters" />
 <fmt:message var="reservationSubmitLabel" key="reservation.form.submit" />
 <fmt:message var="reservationSubmitDisabled" key="reservation.form.submit.disabled" />
+<%@ include file="/common/header.jsp" %>
 
+<%-- ============================================
+     VALIDACIONES
+     ============================================ --%>
+<c:set var="flashSuccess" value="${requestScope.flashSuccess}" />
+<c:set var="flashInfo" value="${requestScope.flashInfo}" />
+<c:set var="flashError" value="${requestScope.flashError}" />
+
+<%-- ============================================
+     FORMULARIO/CONTENIDO
+     ============================================ --%>
 <section class="reservation-section py-6">
     <div class="container">
         <header class="catalog-header">

--- a/src/main/webapp/public/vehicle_detail.jsp
+++ b/src/main/webapp/public/vehicle_detail.jsp
@@ -1,11 +1,24 @@
 <%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
-<%@ include file="/common/header.jsp" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+
+<%-- ============================================
+     CONFIGURACIÓN
+     ============================================ --%>
+<fmt:setLocale value="${sessionScope.appLocale != null ? sessionScope.appLocale : pageContext.request.locale}" scope="session" />
+<fmt:setBundle basename="i18n.Messages" scope="session" />
+<c:set var="ctx" value="${pageContext.request.contextPath}" />
 <c:set var="vehicle" value="${requestScope.vehicle}" />
 <c:set var="cartVehicle"
     value="${not empty requestScope.cartVehicle ? requestScope.cartVehicle : sessionScope.reservationCartVehicle}" />
 <c:set var="categories" value="${requestScope.categories}" />
 <c:set var="headquarters" value="${requestScope.headquarters}" />
 <fmt:message var="vehicleMileageUnit" key="vehicle.catalog.feature.mileage.unit" />
+<%@ include file="/common/header.jsp" %>
+
+<%-- ============================================
+     FORMULARIO/CONTENIDO
+     ============================================ --%>
 <section class="detail-section py-6">
     <div class="container">
         <c:choose>

--- a/src/main/webapp/public/verify_2fa.jsp
+++ b/src/main/webapp/public/verify_2fa.jsp
@@ -1,6 +1,24 @@
 <%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
-<%@ include file="/common/header.jsp" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+
+<%-- ============================================
+     CONFIGURACIÓN
+     ============================================ --%>
+<fmt:setLocale value="${sessionScope.appLocale != null ? sessionScope.appLocale : pageContext.request.locale}" scope="session" />
+<fmt:setBundle basename="i18n.Messages" scope="session" />
+<c:set var="ctx" value="${pageContext.request.contextPath}" />
 <c:set var="errors" value="${requestScope.errors}" />
+<c:set var="pendingEmail" value="${requestScope.pendingEmail}" />
+<%@ include file="/common/header.jsp" %>
+
+<%-- ============================================
+     VALIDACIONES
+     ============================================ --%>
+
+<%-- ============================================
+     FORMULARIO/CONTENIDO
+     ============================================ --%>
 
 <section class="auth-section py-6">
     <div class="container">
@@ -9,11 +27,11 @@
                 <span class="section-eyebrow"><fmt:message key="common.home.hero.badge" /></span>
                 <h2 class="form-title"><fmt:message key="twofactor.title" /></h2>
                 <p class="form-subtitle"><fmt:message key="twofactor.intro" /></p>
-                <c:if test="${not empty requestScope.pendingEmail}">
+                <c:if test="${not empty pendingEmail}">
                     <div class="info-box">
                         <p>
                             <fmt:message key="twofactor.notice">
-                                <fmt:param value="${requestScope.pendingEmail}" />
+                                <fmt:param value="${pendingEmail}" />
                             </fmt:message>
                         </p>
                     </div>
@@ -21,7 +39,7 @@
             </div>
             <form method="post" action="${ctx}/public/security/verify-2fa"
                 class="auth-form form-grid single-column">
-                <input type="hidden" name="email" value="${requestScope.pendingEmail}" />
+                <input type="hidden" name="email" value="${pendingEmail}" />
                 <c:if test="${errors != null and errors.hasError('code')}">
                     <div class="alert alert-danger">${errors.getMessage('code')}</div>
                 </c:if>

--- a/src/main/webapp/public/verify_recovery.jsp
+++ b/src/main/webapp/public/verify_recovery.jsp
@@ -1,5 +1,28 @@
 <%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+
+<%-- ============================================
+     CONFIGURACIÓN
+     ============================================ --%>
+<fmt:setLocale value="${sessionScope.appLocale != null ? sessionScope.appLocale : pageContext.request.locale}" scope="session" />
+<fmt:setBundle basename="i18n.Messages" scope="session" />
+<c:set var="ctx" value="${pageContext.request.contextPath}" />
+<c:set var="flashInfo" value="${requestScope.flashInfo}" />
+<c:set var="email" value="${requestScope.email}" />
+<c:set var="errorEmail" value="${requestScope.errorEmail}" />
+<c:set var="errorCode" value="${requestScope.errorCode}" />
+<c:set var="errorPassword" value="${requestScope.errorPassword}" />
+<c:set var="errorConfirm" value="${requestScope.errorConfirm}" />
 <%@ include file="/common/header.jsp" %>
+
+<%-- ============================================
+     VALIDACIONES
+     ============================================ --%>
+
+<%-- ============================================
+     FORMULARIO/CONTENIDO
+     ============================================ --%>
 <section class="auth-section py-6">
     <div class="container">
         <div class="auth-layout card-common shadow-soft">
@@ -7,20 +30,20 @@
                 <span class="section-eyebrow"><fmt:message key="common.home.hero.badge" /></span>
                 <h2 class="form-title"><fmt:message key="recovery.verify.title" /></h2>
                 <p class="form-subtitle"><fmt:message key="recovery.verify.intro" /></p>
-                <c:if test="${not empty requestScope.flashInfo}">
+                <c:if test="${not empty flashInfo}">
                     <div class="info-box">
-                        <p>${requestScope.flashInfo}</p>
+                        <p>${flashInfo}</p>
                     </div>
                 </c:if>
             </div>
             <form method="post" action="${ctx}/public/security/recovery" class="auth-form form-grid single-column">
                 <input type="hidden" name="action" value="verify" />
-                <input type="hidden" name="email" value="${requestScope.email}" />
-                <c:if test="${not empty requestScope.errorEmail}">
-                    <div class="alert alert-danger">${requestScope.errorEmail}</div>
+                <input type="hidden" name="email" value="${email}" />
+                <c:if test="${not empty errorEmail}">
+                    <div class="alert alert-danger">${errorEmail}</div>
                 </c:if>
-                <c:if test="${not empty requestScope.errorCode}">
-                    <div class="alert alert-danger">${requestScope.errorCode}</div>
+                <c:if test="${not empty errorCode}">
+                    <div class="alert alert-danger">${errorCode}</div>
                 </c:if>
                 <div class="form-group">
                     <label for="code"><fmt:message key="recovery.verify.code" /></label>
@@ -29,15 +52,15 @@
                 <div class="form-group">
                     <label for="password"><fmt:message key="recovery.verify.newPassword" /></label>
                     <input type="password" id="password" name="password" required />
-                    <c:if test="${not empty requestScope.errorPassword}">
-                        <small class="form-text error-text">${requestScope.errorPassword}</small>
+                    <c:if test="${not empty errorPassword}">
+                        <small class="form-text error-text">${errorPassword}</small>
                     </c:if>
                 </div>
                 <div class="form-group">
                     <label for="confirmPassword"><fmt:message key="recovery.verify.confirmPassword" /></label>
                     <input type="password" id="confirmPassword" name="confirmPassword" required />
-                    <c:if test="${not empty requestScope.errorConfirm}">
-                        <small class="form-text error-text">${requestScope.errorConfirm}</small>
+                    <c:if test="${not empty errorConfirm}">
+                        <small class="form-text error-text">${errorConfirm}</small>
                     </c:if>
                 </div>
                 <div class="form-actions full-width">


### PR DESCRIPTION
## Summary
- add JSTL core/fmt directives and locale/bundle setup to public and private JSP views
- reorganize configuration, validation, and content sections before markup
- standardize header/footer placement and reuse flash variables across forms

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69316a8612508323900f383393814fed)