### PR TITLE
Align REST client dependencies with Jakarta namespace

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,21 +120,21 @@
       <version>0.4</version>
     </dependency>
 
-    <!-- Jersey client (puedes dejar javax.ws.rs-api para el cliente) -->
+    <!-- Jersey client Jakarta -->
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-client</artifactId>
-      <version>2.35</version>
+      <version>3.1.5</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
-      <version>2.35</version>
+      <version>3.1.5</version>
     </dependency>
     <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>javax.ws.rs-api</artifactId>
-      <version>2.1.1</version>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
+      <version>3.1.0</version>
     </dependency>
 
     <!-- Tests -->

--- a/src/main/java/com/pinguela/rentexpressweb/controller/ConsumesApi.java
+++ b/src/main/java/com/pinguela/rentexpressweb/controller/ConsumesApi.java
@@ -17,13 +17,13 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.Invocation;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 
 @WebServlet("/consumesapi")


### PR DESCRIPTION
## Summary
- update Jersey client and JAX-RS dependencies to Jakarta 3.x versions
- switch REST client imports in ConsumesApi to jakarta.ws.rs packages

## Testing
- mvn -q -DskipTests package *(fails: unable to download maven-resources-plugin due to 403 from Maven Central)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69316c6d210883239e9e5b07f3e79554)