### PR TITLE
Fix pagination path for public vehicle catalog

### DIFF
--- a/src/main/java/com/pinguela/rentexpressweb/controller/PublicVehicleServlet.java
+++ b/src/main/java/com/pinguela/rentexpressweb/controller/PublicVehicleServlet.java
@@ -127,6 +127,7 @@ public class PublicVehicleServlet extends BasePrivateServlet {
             req.setAttribute("criteria", c);
             req.setAttribute("results", results);
             req.setAttribute("vehicles", results.getResults());
+            req.setAttribute(AppConstants.ATTR_PAGINATION_BASE_PATH, req.getContextPath() + "/public/VehicleServlet");
 
             req.setAttribute("categories", categoryService.findAll(language));
             req.setAttribute("headquarters", headquartersService.findAll());
@@ -182,6 +183,7 @@ public class PublicVehicleServlet extends BasePrivateServlet {
             req.setAttribute("criteria", c);
             req.setAttribute("results", results);
             req.setAttribute("vehicles", results.getResults());
+            req.setAttribute(AppConstants.ATTR_PAGINATION_BASE_PATH, req.getContextPath() + "/public/VehicleServlet");
             req.setAttribute("categories", categoryService.findAll(language));
             req.setAttribute("headquarters", headquartersService.findAll());
             req.setAttribute("cartVehicle", SessionManager.getAttribute(req, ReservationConstants.ATTR_CART_VEHICLE));


### PR DESCRIPTION
## Summary
- ensure vehicle catalog pagination links target the servlet instead of the JSP
- preserve filter parameters while paging through the catalog

## Testing
- mvn -q -DskipTests package *(fails: repository access blocked in environment)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69316eb4b5088323ac3a47d74c61d6d1)