### PR TITLE
Normalize Nero JSP routes

### DIFF
--- a/src/main/webapp/public/index.jsp
+++ b/src/main/webapp/public/index.jsp
@@ -273,7 +273,7 @@
                         <p class="nero-faq mb-3">
                             ¿Tuviste un percance con tu mascota u otra mientras conduces? Reserva una cita con NeroVeterinaria.
                         </p>
-                        <a class="btn btn-primary nero-cta-btn" href="${pageContext.request.contextPath}/public/nero_login.jsp">
+                        <a class="btn btn-primary nero-cta-btn" href="<c:url value='/public/nero_login.jsp' />">
                             <span>Ir al login de Nero</span>
                             <i class="bi bi-arrow-right-short"></i>
                         </a>

--- a/src/main/webapp/public/nero_appointment.jsp
+++ b/src/main/webapp/public/nero_appointment.jsp
@@ -10,7 +10,7 @@
 <head>
   <meta charset="UTF-8" />
   <title><fmt:message key="nero.appointment.title" /></title>
-  <link rel="stylesheet" href="${pageContext.request.contextPath}/css/main.css" />
+  <link rel="stylesheet" href="<c:url value='/css/main.css' />" />
 </head>
 <body>
   <%@ include file="/common/header.jsp" %>
@@ -36,7 +36,7 @@
       </div>
     </c:if>
 
-    <form method="post" action="${pageContext.request.contextPath}/consumesapi">
+    <form method="post" action="<c:url value='/consumesapi' />">
       <input type="hidden" name="action" value="create_appointment" />
 
       <label for="headquartersId"><fmt:message key="nero.appointment.headquarters" /></label>

--- a/src/main/webapp/public/nero_login.jsp
+++ b/src/main/webapp/public/nero_login.jsp
@@ -10,7 +10,7 @@
 <head>
   <meta charset="UTF-8" />
   <title><fmt:message key="nero.login.title" /></title>
-  <link rel="stylesheet" href="${pageContext.request.contextPath}/css/main.css" />
+  <link rel="stylesheet" href="<c:url value='/css/main.css' />" />
 </head>
 <body>
   <%@ include file="/common/header.jsp" %>
@@ -19,7 +19,7 @@
     <h1><fmt:message key="nero.login.heading" /></h1>
     <p><fmt:message key="nero.login.description" /></p>
 
-    <form method="post" action="${pageContext.request.contextPath}/consumesapi">
+    <form method="post" action="<c:url value='/consumesapi' />">
       <label for="email"><fmt:message key="nero.login.email" /></label>
       <input type="email" id="email" name="email" required />
 


### PR DESCRIPTION
## Summary
- use JSTL `c:url` to build Nero login CTA link with proper context path
- update Nero login and appointment pages to generate stylesheet and form routes via `c:url`

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69316fb9dbb483238a10c67806d2ec9d)